### PR TITLE
Replace the RegExp for finding entities

### DIFF
--- a/WebKit/scripts/helper/Core.js
+++ b/WebKit/scripts/helper/Core.js
@@ -294,7 +294,7 @@ function(jQuery, Paths, URI, HostApp, Followings) {
 
         var text = node.innerHTML;
         var mentions_in_text = [];
-        var res = text.match(/(\^\S+)/ig);
+        var res = text.match(/(\^[\w:/.]+)/ig);
 
         if (res) {
             for (var i = 0; i < res.length; i++) {


### PR DESCRIPTION
The previous RegExp (^\S+) captured closing parentheses. This one is a bit less ambitious, though I'm not sure how it will react to special characters in URLs.
