### PR TITLE
Store `user_mac_key` in keychain (Mac OS X only)

### DIFF
--- a/Mac/Controller.h
+++ b/Mac/Controller.h
@@ -63,6 +63,8 @@
 - (void)openURL:(NSString *)url;
 
 - (void)setString:(NSString *)string forKey:(NSString *)aKey;
+- (void)setSecret:(NSString *)string;
+- (NSString *)secret;
 - (NSString *)stringForKey:(NSString *)aKey;
 - (void)storeAccessToken:(NSString *)accessToken secret:(NSString *)secret userId:(NSString *)userId andScreenName:(NSString *)screenName;
 - (void)loggedIn;

--- a/Mac/Controller.m
+++ b/Mac/Controller.m
@@ -63,7 +63,13 @@
         [self logout:self];
         [accessToken setString:@"yes" forKey:@"version-0.2.0-new-login"];
     }
-    
+    if (![accessToken stringForKey:@"version-0.3.0-migrated"]) {
+        [accessToken setString:@"yes" forKey:@"version-0.3.0-migrated"];
+        if ([accessToken stringForKey:@"user_mac_key"]){
+            [accessToken setSecret:[accessToken stringForKey:@"user_mac_key"]];
+            [accessToken setString:nil forKey:@"user_mac_key"];
+        }
+    }
     if (![accessToken stringForKey:@"user_access_token"]) {
         [timelineViewWindow performClose:self];
         [mentionsViewWindow performClose:self];
@@ -71,7 +77,7 @@
     } else {
         [timelineViewWindow makeKeyAndOrderFront:self];
         [self initWebViews];
-    }    
+    }
 }
 
 # pragma mark Init
@@ -231,6 +237,15 @@
     [self.accessToken setString:string forKey:aKey];
 }
 
+- (void)setSecret:(NSString *)string
+{
+    [self.accessToken setSecret:string];
+}
+- (NSString *)secret
+{
+    return [self.accessToken secret];
+}
+
 - (NSString *)stringForKey:(NSString *)aKey
 {
     return [self.accessToken stringForKey:aKey];
@@ -352,7 +367,6 @@
     self.accessToken.secret = secret;
     self.accessToken.userId = userId;
     self.accessToken.screenName = screenName;
-    
     [timelineViewWindow makeKeyAndOrderFront:self];
     
     [[NSNotificationCenter defaultCenter] postNotificationName:@"authentificationSucceded" object:nil];

--- a/Mac/Tentia-Info.plist
+++ b/Mac/Tentia-Info.plist
@@ -42,7 +42,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -57,7 +57,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.lifestyle</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Mac/Tentia.xcodeproj/project.pbxproj
+++ b/Mac/Tentia.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		1FFA36D71177D879006C8562 /* Controller.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FFA36D31177D879006C8562 /* Controller.m */; };
 		1FFA36D81177D879006C8562 /* ViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FFA36D51177D879006C8562 /* ViewDelegate.m */; };
 		1FFA37071177DAF4006C8562 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FFA37061177DAF4006C8562 /* WebKit.framework */; };
+		6B68359B166015C4004F4732 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B68359A166015C4004F4732 /* Security.framework */; };
 		8D15AC2C0486D014006FF6A4 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 2A37F4B9FDCFA73011CA2CEA /* Credits.rtf */; };
 		8D15AC2F0486D014006FF6A4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165FFE840EACC02AAC07 /* InfoPlist.strings */; };
 		8D15AC310486D014006FF6A4 /* NewMessageWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A37F4ACFDCFA73011CA2CEA /* NewMessageWindow.m */; settings = {ATTRIBUTES = (); }; };
@@ -82,6 +83,7 @@
 		2A37F4BAFDCFA73011CA2CEA /* English */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = English; path = English.lproj/Credits.rtf; sourceTree = "<group>"; };
 		2A37F4C4FDCFA73011CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		2A37F4C5FDCFA73011CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		6B68359A166015C4004F4732 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = /System/Library/Frameworks/Security.framework; sourceTree = "<absolute>"; };
 		8D15AC360486D014006FF6A4 /* Tentia-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Tentia-Info.plist"; sourceTree = "<group>"; };
 		8D15AC370486D014006FF6A4 /* Tentia.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tentia.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -91,6 +93,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B68359B166015C4004F4732 /* Security.framework in Frameworks */,
 				1F2D79BD165E8C6B000E8428 /* CoreLocation.framework in Frameworks */,
 				1FDEF722164EFE9100F927F3 /* Growl.framework in Frameworks */,
 				1FA09847144602530079E258 /* libicucore.dylib in Frameworks */,
@@ -108,6 +111,7 @@
 		1058C7A6FEA54F5311CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6B68359A166015C4004F4732 /* Security.framework */,
 				1F2D79BC165E8C6B000E8428 /* CoreLocation.framework */,
 				1FDEF721164EFE9100F927F3 /* Growl.framework */,
 				1FE2FC92117A818D000504B0 /* Sparkle.framework */,

--- a/WebKit/scripts/controller/Oauth.js
+++ b/WebKit/scripts/controller/Oauth.js
@@ -146,7 +146,7 @@ function(HostApp, Paths, Hmac) {
         var access = JSON.parse(responseBody); 
         
         HostApp.setStringForKey(access["access_token"], "user_access_token");
-        HostApp.setStringForKey(access["mac_key"], "user_mac_key");
+        HostApp.setSecret(access["mac_key"]);
         HostApp.setStringForKey(access["mac_algorithm"], "user_mac_algorithm");
         HostApp.setStringForKey(access["token_type"], "user_token_type");
 

--- a/WebKit/scripts/helper/HostApp.js
+++ b/WebKit/scripts/helper/HostApp.js
@@ -10,6 +10,23 @@ define(function() {
             controller.setStringForKey(string, key);
         }
     }
+       
+    HostApp.setSecret = function(string) {
+       
+       if (OS_TYPE == "mac") {
+            controller.setSecret_(string);
+       } else {
+            controller.setStringForKey(string, "user_mac_key");
+       }
+    }
+       
+    HostApp.secret = function() {
+       if (OS_TYPE == "mac") {
+            return controller.secret();
+       } else {
+            return controller.stringForKey("user_mac_key");
+       }
+    }
 
     HostApp.stringForKey = function(key) {
 

--- a/WebKit/scripts/helper/Paths.js
+++ b/WebKit/scripts/helper/Paths.js
@@ -40,7 +40,8 @@ function(jQuery, HostApp, Hmac) {
                         auth_header = Hmac.makeAuthHeader(
                             url, 
                             http_method, 
-                            HostApp.stringForKey("user_mac_key"), 
+                            //HostApp.stringForKey("user_mac_key"),
+                            HostApp.secret(),
                             user_access_token
                         );
                         xhr.setRequestHeader("Authorization", auth_header);


### PR DESCRIPTION
Store `user_mac_key` in keychain (Mac OS X only) and not plain text which could be a small security risk, if another app uses it to send posts, etc…
