### PR TITLE
Fixed entity detection which contain dot at the end

### DIFF
--- a/WebKit/scripts/helper/Core.js
+++ b/WebKit/scripts/helper/Core.js
@@ -644,8 +644,7 @@ function(jQuery, Paths, URI, HostApp, Cache) {
 
         var text = node.innerHTML;
         var mentions_in_text = [];
-        var res = text.match(/(\^[\w:/.]+)/ig);
-
+        var res = text.match(/(\^[\w:/]+\.[\w:/.]+(?:[\w]))/ig);
         if (res) {
             for (var i = 0; i < res.length; i++) {
                 var name = res[i];
@@ -731,8 +730,8 @@ function(jQuery, Paths, URI, HostApp, Cache) {
             })
         }
         
-        var res = text.match(/(\^[\w:/]+\.[\w:/.]+)/ig);
-
+        var res = text.match(/(\^[\w:/]+\.[\w:/.]+(?:[\w]))/ig);
+       
         if (res) {
             for (var i = 0; i < res.length; i++) {
                 var e = res[i].substring(1);


### PR DESCRIPTION
Fixed entity detection for posts like
`Hello ^jeena.net. This is a great test to show this bug.`
Before `^jeena.net.` (including the dot) was detected as entity which is wrong.
