### PR TITLE
remove link outline

### DIFF
--- a/WebKit/css/default.css
+++ b/WebKit/css/default.css
@@ -13,6 +13,7 @@ body {
 a {
 	text-decoration: none;
 	color: #00317a;
+        outline: 0;
 }
 
 ol {


### PR DESCRIPTION
Obsessive-compulsive people like me always have to remove the "a" outline by clicking elsewhere in the window after clicking a link. Is the outline necessary? If not, this will remove it :+1: 
